### PR TITLE
pyphen 0.17.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
 
 about:
   home: https://pyphen.org
-  license: GPL-2.0-or-later AND LGPL-2.1-or-later AND MPL-2.0
+  license: GPL-2.0-or-later AND LGPL-2.1-or-later AND MPL-1.1
   license_family: Other
   license_file:
     - LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,44 @@
 {% set name = "pyphen" %}
-{% set version = "0.14.0" %}
-
-
+{% set version = "0.17.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 596c8b3be1c1a70411ba5f6517d9ccfe3083c758ae2b94a45f2707346d8e66fa
-
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37]
+  skip: True  # [py<39]
 
 requirements:
   host:
     - flit-core >=3.2,<4
     - pip
     - python
-
   run:
     - python
 
 test:
+  source_files:
+    - tests
+    - pyphen
   imports:
     - pyphen
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -v --tb=short tests
 
 about:
-  home: https://pyphen.org/
-  license: GPL-2.0-or-later AND LGPL-2.1-or-later AND MPL-1.1
+  home: https://pyphen.org
+  license: GPL-2.0-or-later AND LGPL-2.1-or-later AND MPL-2.0
   license_family: Other
   license_file:
     - LICENSE

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,4 +1,0 @@
-import pyphen
-
-dic = pyphen.Pyphen(lang='nl_NL')
-assert dic.inserted('lettergrepen') == 'let-ter-gre-pen'


### PR DESCRIPTION
pyphen 0.17.2 

**Destination channel:** Defaults

### Links

- [PKG-10563]
- dev_url:        https://github.com/Kozea/Pyphen/tree/0.17.2
- conda_forge:    https://github.com/conda-forge/pyphen-feedstock
- pypi:           https://pypi.org/project/pyphen/0.17.2
- pypi inspector: https://inspector.pypi.io/project/pyphen/0.17.2

### Explanation of changes:

- version updated from 0.14.0 to 0.17.2
- skip raised to py<39
- added tests
- abs.yaml: added ANACONDA_ROCKET_ENABLE_PY314: yes
- deleted recipe/run_test.py


[PKG-10563]: https://anaconda.atlassian.net/browse/PKG-10563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ